### PR TITLE
Add placeholders for specific form_alter hooks

### DIFF
--- a/Snippets/core/hook_form_BASE_FORM_ID_alter.sublime-snippet
+++ b/Snippets/core/hook_form_BASE_FORM_ID_alter.sublime-snippet
@@ -2,9 +2,9 @@
 	<tabTrigger>h.form_BASE_FORM_ID_alter</tabTrigger>
 	<scope>source.php</scope>
 <content><![CDATA[/**
- * Implements hook_form_BASE_FORM_ID_alter().
+ * Implements hook_form_BASE_FORM_ID_alter() for ${1:BASE_FORM_ID}().
  */
-function ${TM_FILENAME/([^\.]+)\..*/$1/}_form_BASE_FORM_ID_alter(&\$form, &\$form_state, \$form_id) {
+function ${TM_FILENAME/([^\.]+)\..*/$1/}_form_${1}_alter(&\$form, &\$form_state, \$form_id) {
 	$0
 }]]></content>
 </snippet>

--- a/Snippets/core/hook_form_FORM_ID_alter.sublime-snippet
+++ b/Snippets/core/hook_form_FORM_ID_alter.sublime-snippet
@@ -2,9 +2,9 @@
 	<tabTrigger>h.form_FORM_ID_alter</tabTrigger>
 	<scope>source.php</scope>
 <content><![CDATA[/**
- * Implements hook_form_FORM_ID_alter().
+ * Implements hook_form_FORM_ID_alter() for ${1:FORM_ID}().
  */
-function ${TM_FILENAME/([^\.]+)\..*/$1/}_form_FORM_ID_alter(&\$form, &\$form_state, \$form_id) {
+function ${TM_FILENAME/([^\.]+)\..*/$1/}_form_${1}_alter(&\$form, &\$form_state, \$form_id) {
 	$0
 }]]></content>
 </snippet>


### PR DESCRIPTION
- hook_form_BASE_FORM_ID_alter()
- hook_form_FORM_ID_alter()

Also adds the form ID to the docblock as per http://drupal.org/node/1354#functions.

Love this package, btw. I upgraded to ST3 starting with no packages and this got added back pretty early on :)
