### PR TITLE
added layout as used by Omega4 theme

### DIFF
--- a/Drupal Info File/Drupal Info Files.sublime-completions
+++ b/Drupal Info File/Drupal Info Files.sublime-completions
@@ -16,5 +16,6 @@
 		{"trigger": "scripts", "contents": "scripts[] = "},
 		{"trigger": "settings", "contents": "settings[] = "},
 		{"trigger": "stylesheets", "contents": "stylesheets[] = "}
+		{"trigger": "layout", "contents": "layout[] = "}
 	]
 }


### PR DESCRIPTION
In theory that should add highlighting in Omega 4 theme info file for layout:
layout[component][stylesheets][all][] = css/layouts/component/theme-component.layout.css
